### PR TITLE
Fix keyboard shortcut paths for student management and reports

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -113,13 +113,13 @@ function configurarAtalhos() {
         // Ctrl + G para gestão de alunos
         if (e.ctrlKey && e.key === 'g') {
             e.preventDefault();
-            window.location.href = '/páginas/gestao-alunos.html';
+            window.location.href = '/pages/gestao-alunos.html';
         }
         
         // Ctrl + R para relatórios
         if (e.ctrlKey && e.key === 'r') {
             e.preventDefault();
-            window.location.href = '/páginas/relatorios.html';
+            window.location.href = '/pages/relatorios.html';
         }
         
         // ESC para limpar pesquisa


### PR DESCRIPTION
## Summary
- point Ctrl+G shortcut to `/pages/gestao-alunos.html`
- point Ctrl+R shortcut to `/pages/relatorios.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a140b934c4832cbacb89606d6616e1