### PR TITLE
Add Jest test setup and utility tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -313,3 +313,8 @@ window.capitalize = capitalize;
 window.gerarId = gerarId;
 window.debounce = debounce;
 window.fazerBackup = fazerBackup;
+
+// Export functions for Node.js testing environment
+if (typeof module !== 'undefined') {
+    module.exports = { capitalize, gerarId };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sistema-disciplinar-revisado",
+  "version": "1.0.0",
+  "description": "Dashboard para gestão disciplinar escolar: alunos, medidas, relatórios e análises.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,13 @@
+const { capitalize, gerarId } = require('../assets/js/main');
+
+describe('Utility functions', () => {
+  test('capitalize should capitalize first letter', () => {
+    expect(capitalize('aluno')).toBe('Aluno');
+  });
+
+  test('gerarId should generate unique IDs', () => {
+    const id1 = gerarId();
+    const id2 = gerarId();
+    expect(id1).not.toBe(id2);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Node package with Jest and testing script
- export utility functions for Node testing
- add Jest tests for capitalize and gerarId utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a140bae544832c867958acf59d73a1