### PR TITLE
fix: correct script paths on gestao-alunos page

### DIFF
--- a/pages/gestao-alunos.html
+++ b/pages/gestao-alunos.html
@@ -16,13 +16,13 @@
   <script defer src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
 
   <!-- Config do Firebase (deve definir window.db e window.isFirebaseReady) -->
-  <script defer src="/js/firebase-config.js"></script>
+  <script defer src="../assets/js/firebase-config.js"></script>
 
   <!-- Scripts da aplicação (opcional) -->
   <script defer src="../assets/js/main.js"></script>
 
   <!-- CRUD de Alunos (integra com Firestore) -->
-  <script defer src="/js/gestao.js"></script>
+  <script defer src="../assets/js/gestao.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- fix gestao-alunos.html to load Firebase config and gestao scripts from assets directory

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 & pid=$!; sleep 1; curl -I http://localhost:8000/pages/gestao-alunos.html; curl -I http://localhost:8000/assets/js/firebase-config.js; curl -I http://localhost:8000/assets/js/gestao.js; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_68a140b90cfc832cbb2cd8edce1a9b87